### PR TITLE
Changed link in Awesomeness provider on Team page from white to green.

### DIFF
--- a/app/assets/stylesheets/team.css.scss
+++ b/app/assets/stylesheets/team.css.scss
@@ -121,6 +121,10 @@ div.tooltips {
     display: inline;
 }
 
+div.tooltip-description a{
+    color: #83c057;    
+}
+
 div.member-container {
     display: table;
     margin: auto;


### PR DESCRIPTION
This is a new branch for Charissa's changes to make the link visible. Instead of black, we actually are updating links to green now. 