### PR TITLE
Fix footer not positioned on bottom of page #54

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,12 @@ GEM
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jshint (1.5.0)
+      execjs (>= 1.4.0)
+      multi_json (~> 1.0)
+      therubyracer (~> 0.12.1)
     json (1.8.6)
+    libv8 (3.16.14.19-x86_64-darwin-15)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     mime-types (3.1)
@@ -112,6 +117,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     rdoc (4.3.0)
+    ref (2.0.0)
     rspec-core (3.5.2)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -148,6 +154,9 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -172,6 +181,7 @@ DEPENDENCIES
   database_cleaner
   jbuilder (~> 2.0)
   jquery-rails
+  jshint
   pg
   puma
   rails (= 4.1.7)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -75,8 +75,15 @@ a {
   font-family: ArcherBold;
 }
 
+html {
+  height: 100%;
+}
+
 body {
   font-family: ArcherLight;
+  position: relative;
+  padding-bottom: 5em;
+  min-height: 100%;
 }
 
 img {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -10,6 +10,9 @@
   font-family: ArcherLight;
   color: white;
   background: $green;
+  bottom: 0;
+  position: absolute;
+  width: 100%;
 
   a, li {
     color: white;


### PR DESCRIPTION
Fixes #54 iPad mini: footer on Connect page

Issue can also be seen on desktop by zooming out so the page content is smaller than the page height.
<img width="1552" alt="screen shot 2018-10-29 at 11 36 54 pm" src="https://user-images.githubusercontent.com/13934832/47700409-99d11900-dbd3-11e8-8cd0-754fdb5e25a0.png">

After some CSS adjustments, footer is locked to bottom of page:
<img width="1536" alt="screen shot 2018-10-29 at 10 57 17 pm" src="https://user-images.githubusercontent.com/13934832/47700276-26c7a280-dbd3-11e8-8c68-5c41805ce352.png">

It also looks like the Gemfile.lock file was not updated when the `jshint` gem was added recently, so those updates are also included currently