### PR TITLE
Add margin bottom to prevent text being hidden behind footer on mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,10 @@
 @import "bootstrap";
 @import "./_variables";
 
+.container {
+  margin-bottom: 5em;
+}
+
 .page {
   padding-top: 70px;
   width: 100%;


### PR DESCRIPTION
While reviewing PRs, notices a bug: footer was covering some text on /connect, /volunteer and /about pages.See example:
Before this PR:
![screencapture-0-0-0-0-3000-about-2018-11-01-21_34_41](https://user-images.githubusercontent.com/18508181/47894286-46530b00-de1f-11e8-91c9-6205096553cb.png)
After this PR:
![screencapture-0-0-0-0-3000-about-2018-11-01-21_36_20](https://user-images.githubusercontent.com/18508181/47894364-b19cdd00-de1f-11e8-848c-86828818d63a.png)

