### PR TITLE
Mobile toggle

### DIFF
--- a/app/assets/stylesheets/team.css.scss
+++ b/app/assets/stylesheets/team.css.scss
@@ -75,16 +75,21 @@ div.tooltips {
     color: $green !important;
 }
 
-div.tooltips .the-tooltip {
-  position: absolute;
-  width: 300px;
+.the-tooltip{
+  max-width: 300px;
+  margin: 0 auto 10px auto;
   color: $black;
   background: white;
   border: 3px solid $green;
-  padding: 20px;
   text-align: center;
-  visibility: hidden;
   border-radius: 2px;
+  padding: 20px;
+}
+
+div.tooltips .the-tooltip {
+  width: 300px;
+  position: absolute;
+  visibility: hidden;
   left: 50%;
   transform: translateX(-50%);
 }
@@ -92,29 +97,54 @@ div.tooltips .the-tooltip {
 div.tooltips .the-tooltip:before {
   content: '';
   position: absolute;
-  bottom: 100%;
-  left: 50%;
-  margin-left: -12px;
   width: 0; height: 0;
   border-bottom: 12px solid $green;
   border-right: 12px solid transparent;
   border-left: 12px solid transparent;
+  left: 50%;
+  margin-left: -12px;
+  bottom: 100%;
 }
 
 div.tooltips .the-tooltip:after {
   content: '';
   position: absolute;
-  bottom: 100%;
-  left: 50%;
-  margin-left: -8px;
   width: 0; height: 0;
   border-bottom: 8px solid white;
   border-right: 8px solid transparent;
   border-left: 8px solid transparent;
+  left: 50%;
+  margin-left: -8px;
+  bottom: 100%;
 }
 
 div:hover.tooltips .the-tooltip {
   visibility: visible;
   opacity: 1;
   z-index: 999;
+}
+
+.member-container a.linkedin-link,
+.member-container a:hover,
+.member-container a:visited {
+  text-decoration: none;
+  color: #286cac;
+  font-weight: bold;
+}
+
+.flex-container{
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+}
+
+.flex-container>div{
+  width: 25%;
+  padding: 10px;
+}
+@media screen and (max-width: 991px){
+  .flex-container>div{ width: 50%; }
+}
+@media screen and (max-width: 834px){
+  .flex-container>div{ width: 100%; }
 }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -12,6 +12,11 @@ class StaticPagesController < ApplicationController
   end
 
   def team
+    # User Agents found at https://deviceatlas.com/blog/list-of-user-agent-strings
+    # For a general blog of user agents, refer to https://deviceatlas.com/blog/mobile-browser-user-agent-strings
+    # Please update any mobile-based user agents using this array.
+    # You do not need the complete user-agent, just the unique identifying name i.e. Android
+
     @mobileUserAgents = [ #Add any new strings that are found in mobile user agents here
         "Android",
         "webOS",
@@ -19,7 +24,8 @@ class StaticPagesController < ApplicationController
         "iPad",
         "iPod",
         "BlackBerry",
-        "Windows Phone"
+        "Windows Phone",
+        "Opera Mini"
     ]
     @userAgentString = @mobileUserAgents.join("|")
     @regex = Regexp.new @userAgentString

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,7 +2,7 @@ class StaticPagesController < ApplicationController
   def front_page
   end
 
-  def about  
+  def about
   end
 
   def how
@@ -12,6 +12,20 @@ class StaticPagesController < ApplicationController
   end
 
   def team
+    @mobileUserAgents = [ #Add any new strings that are found in mobile user agents here
+        "Android",
+        "webOS",
+        "iPhone",
+        "iPad",
+        "iPod",
+        "BlackBerry",
+        "Windows Phone"
+    ]
+    @userAgentString = @mobileUserAgents.join("|")
+    @regex = Regexp.new @userAgentString
+    @userAgent = request.headers['User-Agent']
+    @isMobile = !!@userAgent.match(/#{@regex}/i)  #This will return true if user is on mobile device
+
     @teamMembers = [
         {
             name: "Nathalie Steinmetz",
@@ -182,5 +196,5 @@ class StaticPagesController < ApplicationController
         }
     ]
   end
-  
+
 end

--- a/app/views/static_pages/team.html.erb
+++ b/app/views/static_pages/team.html.erb
@@ -10,39 +10,75 @@
         <div class="row col mb-3">
             <div class="title">Meet the Team</div>
         </div>
-        <div class="row mt-5">
-            <% @teamMembers.each do |member| -%>
-                <div class="col pt-3 col-sm-6 col-xs-12 col-md-3">
-                    <div class="member-container tooltips">
-                        <%= link_to image_tag(member[:imageUrl], class: "circle"), member[:linkedInUrl], target: "_blank" %>
-                        <div class="name pt-2"><%= member[:name] %></div>
-                        <div class="member-title pb-2"><%= member[:title] %></div>
-                        <% if member[:description] != nil %>
-                            <div class="the-tooltip">
-                                <div class="name pt-2"><%= member[:name] %></div>
-                                <div class="member-title"><%= member[:title] %></div>
-                                <div class="tooltip-description">
-                                    <%= member[:description] %>
+        <div class="flex-container" id="team-members">
+            <% if !@isMobile %>
+                <% @teamMembers.each do |member| -%>
+                    <div class="col pt-3 col-sm-6 col-xs-12 col-md-3">
+                        <div class="member-container tooltips">
+                            <%= link_to image_tag(member[:imageUrl], class: "circle"), member[:linkedInUrl], target: "_blank" %>
+                            <div class="name pt-2"><%= member[:name] %></div>
+                            <div class="member-title pb-2"><%= member[:title] %></div>
+                            <% if member[:description] != nil %>
+                                <div class="the-tooltip">
+                                    <div class="name pt-2"><%= member[:name] %></div>
+                                    <div class="member-title"><%= member[:title] %></div>
+                                    <div class="tooltip-description"><%= member[:description] %></div>
                                 </div>
-                            </div>
-                        <% end %>
+                            <% end %>
+                        </div>
                     </div>
-                </div>
-            <% end -%>
-            <div class="col pt-3 col-sm-6 col-xs-12 col-md-3 end">
-                <div class="member-container tooltips">
-                    <%= image_tag("team/kitten.png", class: "circle") %>
-                    <div class="name pt-2">YOU?</div>
-                    <div class="member-title">Awesomeness Provider</div>
-                    <div class="the-tooltip">
-                        <div class="name pt-2">The Placeholder Kitten</div>
+                <% end -%>
+                <div class="col pt-3 col-sm-6 col-xs-12 col-md-3 end">
+                    <div class="member-container tooltips">
+                        <%= image_tag("team/kitten.png", class: "circle") %>
+                        <div class="name pt-2">YOU?</div>
                         <div class="member-title">Awesomeness Provider</div>
-                        <div class="tooltip-description">
-                            Do you want to become part of the She's Coding team? We would love to have you on board - go ahead <%= link_to "connect with us", "/connect" %> or check out our <%= link_to "volunteer page", "/volunteer" %> for more information!
+                        <div class="the-tooltip">
+                            <div class="name pt-2">The Placeholder Kitten</div>
+                            <div class="member-title">Awesomeness Provider</div>
+                            <div class="tooltip-description">
+                                Do you want to become part of the She's Coding team? We would love to have you on board - go ahead <%= link_to "connect with us", "/connect" %> or check out our <%= link_to "volunteer page", "/volunteer" %> for more information!
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            <% else %>
+                <% @teamMembers.each do |member| -%>
+                    <div class="col" role="tablist" aria-multiselectable="true">
+                        <div class="member-container">
+                            <a role="button" data-toggle="collapse" data-parent="#team-members" href="#<%= (member[:name]).gsub(/\s+/, "") %>" aria-expanded="false" aria-controls="<%= (member[:name]).gsub(/\s+/, "") %>" class="collapsed">
+                                <%= image_tag(member[:imageUrl], class: "circle", role: "tab") %>
+                                <div class="name pt-2"><%= link_to member[:name], member[:linkedInUrl], target: "_blank", class: "linkedin-link" %></div>
+                                <div class="member-title pb-2"><%= member[:title] %></div>
+                            </a>
+                            <div id="<%= (member[:name]).gsub(/\s+/, "") %>" class="panel-collapse collapse" role="tabpanel" aria-label="<%= member[:name] %>">
+                                <% if member[:description] != nil %>
+                                    <div class="the-tooltip">
+                                        <div class="tooltip-description"><%= member[:description] %></div>
+                                    </div>
+                                <% end %>
+                            </div>
+                        </div>
+                    </div>
+                <% end -%>
+                <div class="col end">
+                    <div class="member-container">
+                        <a role="button" data-toggle="collapse" data-parent="#team-members" href="#kitty" aria-expanded="false" aria-controls="kitty" class="collapsed">
+                            <%= image_tag("team/kitten.png", class: "circle", role: "tab") %>
+                            <div class="name pt-2">YOU?</div>
+                            <div class="member-title">Awesomeness Provider</div>
+                        </a>
+                        <div id="kitty" class="panel-collapse collapse" role="tabpanel" aria-label="volunteer">
+                            <div class="the-tooltip">
+                                <div class="name pt-2">The Placeholder Kitten</div>
+                                <div class="tooltip-description">
+                                    Do you want to become part of the She's Coding team? We would love to have you on board - go ahead <%= link_to "connect with us", "/connect" %> or check out our <%= link_to "volunteer page", "/volunteer", class: "linkedin-link" %> for more information!
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <% end %>
         </div>
     </div>
 <!--- End of: Active members of the team section -->
@@ -52,21 +88,40 @@
         <div class="row col mb-3">
             <div class="title white-color">Advisors</div>
         </div>
-        <div class="row mt-5">
-            <div class="col pt-3 col-sm-6 col-xs-12 col-md-3 end">
-                <div class="member-container tooltips">
-                    <%= link_to image_tag("team/robin.png", class: "circle"), "https://www.linkedin.com/in/robinhauser/", target: "_blank" %>
-                    <div class="name pt-2">Robin Hauser Reynolds</div>
-                    <div class="member-title">Director/Producer, CODE: Debugging the Gender Gap</div>
-                    <div class="the-tooltip">
+        <div class="flex-container" id="advisors">
+            <% if !@isMobile %>
+                <div class="col end">
+                    <div class="member-container tooltips">
+                        <%= link_to image_tag("team/robin.png", class: "circle"), "https://www.linkedin.com/in/robinhauser/", target: "_blank" %>
                         <div class="name pt-2">Robin Hauser Reynolds</div>
                         <div class="member-title">Director/Producer, CODE: Debugging the Gender Gap</div>
-                        <div class="tooltip-description">
-                            As both a business woman and a longtime professional photographer, Robin brings her creative eye and leadership skills to the CODE documentary project. Her years in fine art photography give her a keen vision for the artistic design of CODE; her experience in the business world affords her a unique perspective on what it takes to change an industry. Previously, Robin co-directed and produced the documentary feature, Running for Jim, which won 14 awards at 16 film festivals in the U.S. and abroad.
+                        <div class="the-tooltip">
+                            <div class="name pt-2">Robin Hauser Reynolds</div>
+                            <div class="member-title">Director/Producer, CODE: Debugging the Gender Gap</div>
+                            <div class="tooltip-description">
+                                As both a business woman and a longtime professional photographer, Robin brings her creative eye and leadership skills to the CODE documentary project. Her years in fine art photography give her a keen vision for the artistic design of CODE; her experience in the business world affords her a unique perspective on what it takes to change an industry. Previously, Robin co-directed and produced the documentary feature, Running for Jim, which won 14 awards at 16 film festivals in the U.S. and abroad.
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            <% else %>
+                <div class="col pt-3 col-sm-6 col-xs-12 col-md-3 end">
+                    <div class="member-container">
+                        <a role="button" data-toggle="collapse" data-parent="#advisors" href="#RobinHauserRenolds" aria-expanded="false" aria-controls="RobinHauserRenolds" class="collapsed">
+                        <%= image_tag("team/robin.png", class: "circle", role: "tab") %>
+                            <div class="name pt-2"><%= link_to "Robin Hauser Renolds", "https://www.linkedin.com/in/robinhauser/", target: "_blank", class: "linkedin-link" %></div>
+                            <div class="member-title">Director/Producer, CODE: Debugging the Gender Gap</div>
+                        </a>
+                        <div id="RobinHauserRenolds" class="panel-collapse collapse" role="tabpanel" aria-label="Robin Hauser Reynolds">
+                            <div class="the-tooltip">
+                                <div class="tooltip-description">
+                                    As both a business woman and a longtime professional photographer, Robin brings her creative eye and leadership skills to the CODE documentary project. Her years in fine art photography give her a keen vision for the artistic design of CODE; her experience in the business world affords her a unique perspective on what it takes to change an industry. Previously, Robin co-directed and produced the documentary feature, Running for Jim, which won 14 awards at 16 film festivals in the U.S. and abroad.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <% end %>
         </div>
     </div>
 <!--- End of: Advisors section -->


### PR DESCRIPTION
This pull request may need style updates for the linkedin links, but it is a good place to start:

If the device is mobile, the team member's face is a toggle link while their name is the team member's linked in page

To do this, the controller read's the user's userAgent. Then, the user agent is run against a regex of all common mobile browser names. The Regex is generated by merging an array into a string and converting to regex. This way, it will be very easy to add and remove any mobile browser names if the need every arises.

The variable that compares the regex returns either true or false.

If false, the original layout is used, with the exception of new flex stylings that have been added (see below)

If true, a new toggle layout is used. During testing, it became apparent that the parent div, which was using bootstrap md-5, would not work because the toggle would break any floating elements below, and they would snap into a new line just after the description div. To fix this, the parent div now uses flexbox. The class flex-container is defined in the css, and the media queries below mimic the breakpoints of bootstrap forcing the same layout structure without any of the float breaking that occurred earlier.