### PR TITLE
Fix testimonials slider

### DIFF
--- a/app/views/static_pages/front_page.html.erb
+++ b/app/views/static_pages/front_page.html.erb
@@ -48,7 +48,7 @@
 						<li>We are merging our Seattle and Seattle Eastside chapters into one. Visit the <a href="https://www.meetup.com/shescoding-seattle/" target="_blank">Seattle</a> group to find meetups in Seattle, Redmond and Bellevue.</li>
 						<li>We will be launching our next Seattle two-month-long Code-a-thon soon - stay tuned!</li>
 						<li>We have brought in new energy from the holiday period to continue planning our June Seattle <a href="http://techwomenrising.org" target="_blank">Tech Women Rising conference</a>!</li>
-						<li>We added <a href="#carousel-testimonials"> testimonials</a> to the site - we love sharing the love we get from our members! </li>
+						<li>We added <a href="#testimonials"> testimonials</a> to the site - we love sharing the love we get from our members! </li>
 						<li>Developing more new features for this website - keep a lookout for changes such as an events page, new resources, and others.</li>
 					</ul>
 				</section>
@@ -130,9 +130,9 @@
 						</div>
 				</section>
 
-				<section id="carousel-testimonials" class="section site-section testimonials">
+				<section id="testimonials" class="section site-section testimonials">
 					<h2>Testimonials</h2>
-					<div class="carousel slide" data-interval="false">
+					<div id="carousel-testimonials" class="carousel slide" data-interval="false">
 						<div class="carousel-inner">
 							<!-- Testimonial 1 -->
 							<div class="item active">


### PR DESCRIPTION
Moved carousel-testimonials id back to the div it was at before.
Created new testimonials id for the section and linked to that in the link to testimonials under What's New.

This fixes #177