### PR TITLE
Fix disappearing text in Firefox

### DIFF
--- a/app/assets/stylesheets/team.css.scss
+++ b/app/assets/stylesheets/team.css.scss
@@ -68,7 +68,7 @@ $past_cont_grey: #808080;
 //tooltip related css is below
 div.tooltips {
     position: relative;
-    display: inline;
+    display: inline-block;
 }
 
 .tooltip-description a {


### PR DESCRIPTION
I'm not sure why `div.tooltips` was being displayed as `inline`, but removing that line altogether or changing it to `inline-block` fixes the issue with Firefox. I thought it might be safer to use `inline-block` if there was a reason for it to be inline. This fixes #170 

Another thing you might notice after resolving this issue - when hovering over the links in the tooltip for "YOU? Awesomeness Provider" locally, the link text becomes bold and makes other text shift in Firefox. However on shescoding.org, these same links get underlined upon hover instead (in Chrome, and in Firefox if you fix the issue in dev tools) and no text gets displaced, so I think that it will look ok once changes are applied to the site, but the CSS isn't doing exactly what's intended and may need further cleanup.

